### PR TITLE
Add "Don't add torrent's name to path" to settings

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ net.xirvik.seedbox = (function(my)
 			messagesf: true,        /* Server login failure */
 			messagest: true,        /* Server connection timeout */
 			nostart:   false,       /* Upload without starting the torrent automatically */
+			not_add_path: false,    /* Don't add torrent's name to path */
 			timeout:   15,          /* Timeout value, in seconds, for server connections */
 			console:   true,        /* Show console output */
 			enabled:   true	 	/* is extension enabled */

--- a/document_event.js
+++ b/document_event.js
@@ -182,6 +182,7 @@ net.xirvik.seedbox = (function(my)
 							else
 								$('.xirvik-dlg #directories').hide();
 							$('.xirvik-dlg #torrents_start_stopped').attr('checked',my.extension.options.nostart);
+							$('.xirvik-dlg #not_add_path').attr('checked',my.extension.options.not_add_path);
 							$('.xirvik-dlg button.cancel').click( function()
 							{
 								$.fancybox.close();

--- a/options.html
+++ b/options.html
@@ -87,6 +87,7 @@
 					<legend data-i18n='upload_options_rutorrent_only'></legend>
 					<box>
 						<label><input type="checkbox" id="upload-nostart" /><span data-i18n='upload_without_starting'></span></label>
+						<label><input type="checkbox" id="upload-not-add-path" /><span data-i18n='Dont_add_tname'></span></label>
 					</box>
 				</fieldset>
 				<br />

--- a/options.js
+++ b/options.js
@@ -202,6 +202,7 @@ net.xirvik.seedbox = (function(my)
 			$("#progress-messageuc").prop('checked',my.extension.options.messageuc);
 			$("#progress-messageuf").prop('checked',my.extension.options.messageuf);
 			$("#upload-nostart").prop('checked',my.extension.options.nostart);
+			$("#upload-not-add-path").prop('checked',my.extension.options.not_add_path);
 			$("#console").prop('checked',my.extension.options.console);
 			$("#enabled").prop('checked',my.extension.options.enabled);
 			$("#upload-timeout").val(my.extension.options.timeout);
@@ -249,6 +250,7 @@ net.xirvik.seedbox = (function(my)
 				messageuc: $("#progress-messageuc").prop('checked'),
 				messageuf: $("#progress-messageuf").prop('checked'),
 				nostart: $("#upload-nostart").prop('checked'),
+				not_add_path: $("#upload-not-add-path").prop('checked'),
 				console: $("#console").prop('checked'),
 				enabled: $("#enabled").prop('checked'),
 				timeout: parseInt($("#upload-timeout").val()),


### PR DESCRIPTION
Add an option to set the default state of "Don't add torrent's name to path" in the torrent add dialog.